### PR TITLE
[FEATURE] 태그 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/octagram/pollet/survey/domain/service/SurveyService.java
+++ b/src/main/java/com/octagram/pollet/survey/domain/service/SurveyService.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SurveyService {
     private final TagRepository tagRepository;
+    private final SurveyTagRepository surveyTagRepository;
 
     @Transactional(readOnly = true)
     public List<TagResponse> getAllTags() {
@@ -23,6 +24,14 @@ public class SurveyService {
                 .map(TagResponse::from)
                 .collect(Collectors.toList());
     }
+
+    @Transactional(readOnly = true)
+    public List<TagResponse> getAllUsedTags() {
+        return surveyTagRepository.findAllUsedTags().stream()
+                .map(TagResponse::from)
+                .toList();
+    }
+
 
 
 

--- a/src/main/java/com/octagram/pollet/survey/domain/service/SurveyService.java
+++ b/src/main/java/com/octagram/pollet/survey/domain/service/SurveyService.java
@@ -1,10 +1,34 @@
 package com.octagram.pollet.survey.domain.service;
 
+import com.octagram.pollet.survey.domain.model.SurveyTag;
+import com.octagram.pollet.survey.dto.TagResponse;
+import com.octagram.pollet.survey.repository.SurveyTagRepository;
+import com.octagram.pollet.survey.repository.TagRepository;
 import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class SurveyService {
+    private final TagRepository tagRepository;
+
+    @Transactional(readOnly = true)
+    public List<TagResponse> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(TagResponse::from)
+                .collect(Collectors.toList());
+    }
+
+
+
+
+
+
+
+
 }

--- a/src/main/java/com/octagram/pollet/survey/dto/TagResponse.java
+++ b/src/main/java/com/octagram/pollet/survey/dto/TagResponse.java
@@ -1,0 +1,16 @@
+package com.octagram.pollet.survey.dto;
+
+import com.octagram.pollet.survey.domain.model.Tag;
+
+public record TagResponse(
+        Long id,
+        String name
+) {
+
+    public static TagResponse from(Tag tag) {
+        return new TagResponse(
+                tag.getId(),
+                tag.getName()
+        );
+    }
+}

--- a/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
+++ b/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
@@ -24,7 +24,6 @@ public class SurveyController {
         return ResponseEntity.ok(tags);
     }
 
-    // 설문조사에 사용된 태그 중복 제거 후 조회
     @GetMapping("/usedTags")
     @Operation(summary = "설문조사에서 사용된 태그 조회", description = "중복 제거된 설문조사 태그를 조회합니다.")
     public ResponseEntity<List<TagResponse>> getAllUsedTags() {

--- a/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
+++ b/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
@@ -1,12 +1,26 @@
 package com.octagram.pollet.survey.presentation.controller;
 
+import com.octagram.pollet.survey.domain.service.SurveyService;
+import com.octagram.pollet.survey.dto.TagResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
-
 import lombok.RequiredArgsConstructor;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/survey")
 @RequiredArgsConstructor
 public class SurveyController {
+
+    private final SurveyService surveyService;
+
+    @GetMapping("/tags")
+    public ResponseEntity<List<TagResponse>> getAllTags() {
+        List<TagResponse> tags = surveyService.getAllTags();
+        return ResponseEntity.ok(tags);
+    }
+
+
 }

--- a/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
+++ b/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
@@ -2,6 +2,7 @@ package com.octagram.pollet.survey.presentation.controller;
 
 import com.octagram.pollet.survey.domain.service.SurveyService;
 import com.octagram.pollet.survey.dto.TagResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +18,7 @@ public class SurveyController {
     private final SurveyService surveyService;
 
     @GetMapping("/tags")
+    @Operation(summary = "모든 태그 조회", description = "등록 가능한 모든 태그를 조회합니다.")
     public ResponseEntity<List<TagResponse>> getAllTags() {
         List<TagResponse> tags = surveyService.getAllTags();
         return ResponseEntity.ok(tags);
@@ -24,6 +26,7 @@ public class SurveyController {
 
     // 설문조사에 사용된 태그 중복 제거 후 조회
     @GetMapping("/usedTags")
+    @Operation(summary = "설문조사에서 사용된 태그 조회", description = "중복 제거된 설문조사 태그를 조회합니다.")
     public ResponseEntity<List<TagResponse>> getAllUsedTags() {
         List<TagResponse> tags = surveyService.getAllUsedTags();
         return ResponseEntity.ok(tags);

--- a/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
+++ b/src/main/java/com/octagram/pollet/survey/presentation/controller/SurveyController.java
@@ -22,5 +22,12 @@ public class SurveyController {
         return ResponseEntity.ok(tags);
     }
 
+    // 설문조사에 사용된 태그 중복 제거 후 조회
+    @GetMapping("/usedTags")
+    public ResponseEntity<List<TagResponse>> getAllUsedTags() {
+        List<TagResponse> tags = surveyService.getAllUsedTags();
+        return ResponseEntity.ok(tags);
+    }
+
 
 }

--- a/src/main/java/com/octagram/pollet/survey/repository/SurveyTagRepository.java
+++ b/src/main/java/com/octagram/pollet/survey/repository/SurveyTagRepository.java
@@ -1,0 +1,21 @@
+package com.octagram.pollet.survey.repository;
+
+import com.octagram.pollet.survey.domain.model.SurveyTag;
+import com.octagram.pollet.survey.domain.model.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SurveyTagRepository extends JpaRepository<SurveyTag, Long> {
+    // 실제 설문에 한 번이라도 연결된 태그만 조회
+    @Query("""
+        select distinct st.tag
+        from SurveyTag st
+    """)
+    List<Tag> findAllUsedTags();
+
+
+}

--- a/src/main/java/com/octagram/pollet/survey/repository/TagRepository.java
+++ b/src/main/java/com/octagram/pollet/survey/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package com.octagram.pollet.survey.repository;
+
+import com.octagram.pollet.survey.domain.model.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}


### PR DESCRIPTION
## 관련 Issue (필수)
- close #18 
## 주요 변경 사항 (필수)
- tagResposne DTO 추가
- 등록 가능한 모든 태그 조회 기능 구현
- 설문조사에 실제 사용된 태그 조회 (중복 제거) 기능 구현

## 리뷰어 참고 사항
- 개발자가 사전에 정의해둔 태그 목록을 클라이언트에서 조회 하는 걸 가정하여 구현했습니다.
- 사용자가 태그를 활용해서 설문조사를 조회할 땐 설문조사에 등록된 태그들을 기반으로 조회되도록 태그 목록을 제공합니다.

## 추가 정보
- 목데이터 기반으로 API 호출 및 응답이 정상 동작하는지 검증하였습니다.
<img width="473" height="81" alt="스크린샷 2025-08-29 오후 4 45 11" src="https://github.com/user-attachments/assets/22a30ee9-57f2-4383-a995-1ea22e4cb041" />

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [ ] 제목이 Issue와 동일함을 확인했습니다.
- [ ] 리뷰어를 지정했습니다.
- [ ] 프로젝트를 연결했습니다.