### PR TITLE
[FEATURE] 액세스 토큰 재발급 엔드포인트 구현

### DIFF
--- a/src/main/java/com/octagram/pollet/auth/application/service/AuthService.java
+++ b/src/main/java/com/octagram/pollet/auth/application/service/AuthService.java
@@ -1,0 +1,53 @@
+package com.octagram.pollet.auth.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.octagram.pollet.auth.presentation.dto.response.AuthReissueResponse;
+import com.octagram.pollet.global.exception.BusinessException;
+import com.octagram.pollet.global.jwt.repository.TokenRedisRepository;
+import com.octagram.pollet.global.jwt.service.JwtService;
+import com.octagram.pollet.global.jwt.status.JwtErrorCode;
+import com.octagram.pollet.member.domain.model.Member;
+import com.octagram.pollet.member.domain.repository.MemberRepository;
+import com.octagram.pollet.member.domain.status.MemberErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final JwtService jwtService;
+	private final TokenRedisRepository tokenRepository;
+	private final MemberRepository memberRepository;
+
+	public AuthReissueResponse reissueAccessToken(String refreshToken) {
+		String memberId = validateRefreshToken(refreshToken);
+
+		Member member = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		String newAccessToken = jwtService.createAccessToken(memberId, member.getEmail(), member.getRole().toString());
+
+		return new AuthReissueResponse(newAccessToken);
+	}
+
+	private String validateRefreshToken(String refreshToken) {
+		if (refreshToken == null || refreshToken.isEmpty()) {
+			throw new BusinessException(JwtErrorCode.REFRESH_TOKEN_INVALID);
+		}
+
+		if (!jwtService.validateRefreshToken(refreshToken)) {
+			throw new BusinessException(JwtErrorCode.REFRESH_TOKEN_INVALID);
+		}
+
+		String memberId = jwtService.getMemberIdFromToken(refreshToken)
+			.orElseThrow(() -> new BusinessException(JwtErrorCode.REFRESH_TOKEN_INVALID));
+
+		if (!tokenRepository.existsToken(memberId, refreshToken)) {
+			throw new BusinessException(JwtErrorCode.REFRESH_TOKEN_INVALID);
+		}
+
+		return memberId;
+	}
+}

--- a/src/main/java/com/octagram/pollet/auth/application/service/CustomUserOAuth2Service.java
+++ b/src/main/java/com/octagram/pollet/auth/application/service/CustomUserOAuth2Service.java
@@ -1,9 +1,8 @@
-package com.octagram.pollet.auth.application;
+package com.octagram.pollet.auth.application.service;
 
 import java.util.Collections;
 import java.util.Map;
 
-import com.octagram.pollet.member.domain.model.type.Role;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;

--- a/src/main/java/com/octagram/pollet/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/octagram/pollet/auth/handler/OAuth2LoginSuccessHandler.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 import com.octagram.pollet.auth.infrastructure.CustomOAuth2User;
+import com.octagram.pollet.global.jwt.repository.TokenRedisRepository;
 import com.octagram.pollet.global.jwt.service.JwtService;
 import com.octagram.pollet.member.domain.model.type.Role;
 
@@ -21,6 +22,7 @@ import com.octagram.pollet.member.domain.model.type.Role;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
 	private final JwtService jwtService;
+	private final TokenRedisRepository tokenRepository;
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -53,10 +55,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 		String accessToken = jwtService.createAccessToken(
 			oAuth2User.getMemberId(), oAuth2User.getEmail(), oAuth2User.getRole().toString()
 		);
-		String refreshToken = jwtService.createRefreshToken();
+		String refreshToken = jwtService.createRefreshToken(oAuth2User.getMemberId());
 
 		jwtService.sendAccessToken(response, accessToken);
 		jwtService.setRefreshToken(response, refreshToken);
+
+		tokenRepository.save(oAuth2User.getMemberId(), refreshToken);
 
 		// TODO: 프론트 메인 페이지 주소로 리다이렉트
 		response.sendRedirect("/");

--- a/src/main/java/com/octagram/pollet/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/octagram/pollet/auth/presentation/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.octagram.pollet.auth.presentation.controller;
+
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.octagram.pollet.auth.application.service.AuthService;
+import com.octagram.pollet.auth.presentation.dto.response.AuthReissueResponse;
+import com.octagram.pollet.global.dto.ApiResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@GetMapping("/reissue")
+	public ApiResponse<AuthReissueResponse> reissueAccessToken(@CookieValue(value = "RefreshToken", required = false) String refreshToken) {
+		AuthReissueResponse authReissueResponse = authService.reissueAccessToken(refreshToken);
+		return ApiResponse.success(authReissueResponse);
+	}
+}

--- a/src/main/java/com/octagram/pollet/auth/presentation/controller/LoginPageController.java
+++ b/src/main/java/com/octagram/pollet/auth/presentation/controller/LoginPageController.java
@@ -1,4 +1,4 @@
-package com.octagram.pollet.auth.presentation;
+package com.octagram.pollet.auth.presentation.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/octagram/pollet/auth/presentation/dto/response/AuthReissueResponse.java
+++ b/src/main/java/com/octagram/pollet/auth/presentation/dto/response/AuthReissueResponse.java
@@ -1,0 +1,6 @@
+package com.octagram.pollet.auth.presentation.dto.response;
+
+public record AuthReissueResponse(
+	String accessToken
+) {
+}

--- a/src/main/java/com/octagram/pollet/global/config/SecurityConfig.java
+++ b/src/main/java/com/octagram/pollet/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
 		"/",
 		"/oauth2/authorization/**",
 		"/login/oauth2/**",
+		"/api/v1/auth/reissue",
 		"/health",
 		"/actuator/**",
 		"/swagger-ui/**"

--- a/src/main/java/com/octagram/pollet/global/config/SecurityConfig.java
+++ b/src/main/java/com/octagram/pollet/global/config/SecurityConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import com.octagram.pollet.auth.application.CustomUserOAuth2Service;
+import com.octagram.pollet.auth.application.service.CustomUserOAuth2Service;
 import com.octagram.pollet.auth.handler.OAuth2LoginFailureHandler;
 import com.octagram.pollet.auth.handler.OAuth2LoginSuccessHandler;
 import com.octagram.pollet.global.jwt.filter.JwtAuthFilter;

--- a/src/main/java/com/octagram/pollet/global/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/com/octagram/pollet/global/jwt/filter/JwtAuthFilter.java
@@ -30,6 +30,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 		"/",
 		"/oauth2/authorization/**",
 		"/login/oauth2/**",
+		"/api/v1/auth/reissue",
 		"/health",
 		"/actuator",
 		"/swagger-ui/**"

--- a/src/main/java/com/octagram/pollet/global/jwt/repository/TokenRedisRepository.java
+++ b/src/main/java/com/octagram/pollet/global/jwt/repository/TokenRedisRepository.java
@@ -19,8 +19,8 @@ public class TokenRedisRepository {
 	@Value("${jwt.refresh.expiration}")
 	public Long refreshTokenExpiration;
 
-	public void save(String email, String token) {
-		String key = getRedisKey(email, token);
+	public void save(String memberId, String token) {
+		String key = getRedisKey(memberId, token);
 
 		redisTemplate.opsForValue().set(
 			key,
@@ -30,19 +30,19 @@ public class TokenRedisRepository {
 		);
 	}
 
-	public boolean existsToken(String email, String token) {
-		String key = getRedisKey(email, token);
+	public boolean existsToken(String memberId, String token) {
+		String key = getRedisKey(memberId, token);
 
 		return redisTemplate.hasKey(key);
 	}
 
-	public void delete(String email, String token) {
-		String key = getRedisKey(email, token);
+	public void delete(String memberId, String token) {
+		String key = getRedisKey(memberId, token);
 
 		redisTemplate.delete(key);
 	}
 
-	private String getRedisKey(String email, String token) {
-		return String.format(REDIS_REFRESH_TOKEN_KEY, email, token);
+	private String getRedisKey(String memberId, String token) {
+		return String.format(REDIS_REFRESH_TOKEN_KEY, memberId, token);
 	}
 }

--- a/src/main/java/com/octagram/pollet/global/jwt/status/JwtErrorCode.java
+++ b/src/main/java/com/octagram/pollet/global/jwt/status/JwtErrorCode.java
@@ -12,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 public enum JwtErrorCode implements BaseCode {
 
 	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "JE_001", "토큰이 유효하지 않습니다."),
-	ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JE_002" , "액세스 토큰이 만료되었습니다.");
+	REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "JE_002", "리프레시 토큰이 유효하지 않습니다."),
+	ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JE_003" , "액세스 토큰이 만료되었습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/octagram/pollet/member/domain/status/MemberErrorCode.java
+++ b/src/main/java/com/octagram/pollet/member/domain/status/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package com.octagram.pollet.member.domain.status;
+
+import org.springframework.http.HttpStatus;
+
+import com.octagram.pollet.global.status.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements BaseCode {
+
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ME_001", "회원 정보를 찾을 수 없습니다");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #59 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- auth controller, service 패키지 이동
- jwt 로직 및 redis 로직 수정
- 액세스 토큰 재발급 엔드포인트 추가

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
#### ✔️ 로컬 환경에서 테스트 할 때

- `auth/infrastructure/OAuthAttributes.java` - toEntity() 메서드의 Role을 MEMBER로 변경해주세요!
   <img width="791" height="204" alt="image" src="https://github.com/user-attachments/assets/b831aeb1-6b51-4a1b-bbd7-c04b26727bf0" />

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 액세스 토큰 재발급 API(/api/v1/auth/reissue) 추가. 브라우저 쿠키의 리프레시 토큰을 사용해 새 액세스 토큰을 반환.
- Security
  - 로그인 성공 시 리프레시 토큰을 안전한 쿠키(SameSite=None, Path=/, 만료시간 설정)로 전달 및 서버에 저장.
  - 재발급 엔드포인트를 인증 제외 대상으로 허용해 만료 후에도 원활히 갱신 가능.
- Refactor
  - 인증/로그인 관련 패키지 구조 정리로 구성 일관성 향상.
- Chores
  - 토큰 만료/유효성에 대한 에러 코드 추가 및 정비로 오류 응답 명확화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->